### PR TITLE
Speed up segmentation and feature calculation

### DIFF
--- a/features.py
+++ b/features.py
@@ -7,6 +7,7 @@ import pandas as pd
 import scipy.ndimage
 from PIL import Image
 from tqdm import tqdm
+from scipy.sparse import coo_matrix, csr_matrix
 
 Image.MAX_IMAGE_PIXELS = None
 


### PR DESCRIPTION
The current implementation of feature calculation is extremely slow (takes more time than the segmentation itself for large images). I suggest speeding it up using sparse matrices.

- [x] Post hoc feature calculation on the whole image (FastNucleiFeatures class)
- [ ] Add option for sparse matrix storage (convenient for downstream analysis)
- [ ] Try to speed up build in NucleiFeatures class. It should be less memory intense but might not add that much speed at the end 
- [ ] Change example notebook

Happy to hear your suggestions @yozhikoff 
